### PR TITLE
fix: silently fail when network times out

### DIFF
--- a/VisWakeClock/Weather/OpenWeather.swift
+++ b/VisWakeClock/Weather/OpenWeather.swift
@@ -30,6 +30,10 @@ class WeatherClient {
           // silently fail due to offline errors
           print("Network error: No internet connection or network connection lost.")
           return nil
+        case .timedOut:
+          // silently fail due to offline errors
+          print("Network error: Connection timed out.")
+          return nil
         default:
           throw error
         }


### PR DESCRIPTION
Don't alert to Sentry when the network times out when connecting to fetch weather