### PR TITLE
Remove unnecessary @MainActor

### DIFF
--- a/VisWakeClock/Weather/WeatherManager.swift
+++ b/VisWakeClock/Weather/WeatherManager.swift
@@ -15,7 +15,6 @@ enum WeatherError: Error {
   case invalidData
 }
 
-@MainActor
 class WeatherManager: ObservableObject {
   @Published var weather: WeatherData?
   @Published var isLoading = true


### PR DESCRIPTION
I'm unclear if this is problematic, but I read that you shouldn't use Actors with ObservableObject because it can block async work on the main thread.

It appears to compile file without the `@MainActor` so I'm going with it.