### PR TITLE
feat: wrap statsig and sentry in a facade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Select Xcode
-      run: sudo xcode-select -switch /Applications/Xcode_16.0.app && /usr/bin/xcodebuild -version
+      run: sudo xcode-select -switch /Applications/Xcode_16.3.app && /usr/bin/xcodebuild -version
     - name: Run tests
-      run: xcodebuild test -project VisWakeClock.xcodeproj -scheme VisWakeClock -destination 'platform=iOS Simulator,name=iPad (10th generation),OS=18.2' | xcpretty && exit ${PIPESTATUS[0]}      
+      run: xcodebuild -project VisWakeClock.xcodeproj -scheme VisWakeClock -destination 'platform=iOS Simulator,name=iPad (A16),OS=18.4' test | xcpretty && exit ${PIPESTATUS[0]}

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
 .sentryclirc
+.mcp.json
+**/.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ xcodebuild \
   -project VisWakeClock.xcodeproj \
   -scheme VisWakeClock \
   -sdk iphonesimulator \
-  -destination 'platform=iOS Simulator,name=iPad (10th generation),OS=18.2' \
+  -destination 'platform=iOS Simulator,name=iPad (A16),OS=18.4' \
   test
 ```
 

--- a/VisWakeClock/ContentView.swift
+++ b/VisWakeClock/ContentView.swift
@@ -5,8 +5,6 @@
 //  Created by Eric Masiello on 9/15/24.
 //
 
-import Sentry
-import Statsig
 import SwiftData
 import SwiftUI
 
@@ -19,10 +17,11 @@ struct ContentView: View {
   let userConfig: UserConfiguration
   @Environment(\.scenePhase) var scenePhase
   @State private var navigationPath = NavigationPath()
-  
+
   init(userConfig: UserConfiguration) {
-    self.userConfig = userConfig    
-    Statsig.updateUserWithResult(StatsigUser(userID: userConfig.stringId))
+    self.userConfig = userConfig
+
+    AnalyticsLogger.updateUserWithResult(userId: userConfig.stringId)
   }
 
   var body: some View {
@@ -46,13 +45,7 @@ struct ContentView: View {
       .statusBar(hidden: true)
     #endif
       .onChange(of: scenePhase) { _, newPhase in
-        /**
-         I'm unclear if this is the best pattern but the Statsig docs recommend flushing the events when the app goes inactive/background.
-         See https://docs.statsig.com/client/iosClientSDK#shutting-statsig-down
-         */
-        if newPhase == .inactive || newPhase == .background {
-          Statsig.shutdown()
-        }
+        AnalyticsLogger.shutDown(scenePhase: newPhase)
       }
   }
 }

--- a/VisWakeClock/HomeClockView.swift
+++ b/VisWakeClock/HomeClockView.swift
@@ -5,7 +5,6 @@
 //  Created by Eric Masiello on 11/11/24.
 //
 
-import Statsig
 import SwiftUI
 
 typealias HandleBackTapped = () -> Void
@@ -108,7 +107,7 @@ struct HomeClockView: View {
     .accessibilityLabel(Text("Current time is \(currentTime). Tap to return the main view"))
     .buttonStyle(.plain)
     .onAppear {
-      Statsig.logEvent("homeClockViewDidAppear")
+      AnalyticsLogger.log(eventName: "homeClockViewDidAppear")
       #if os(iOS)
         UIApplication.shared.isIdleTimerDisabled = self.userConfiguration.isIdleTimerDisabled
       #endif

--- a/VisWakeClock/SettingsView.swift
+++ b/VisWakeClock/SettingsView.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Eric Masiello on 11/11/24.
 //
-import Statsig
 import SwiftData
 import SwiftUI
 
@@ -47,7 +46,7 @@ struct SettingsView: View {
           }
           
           self.userConfiguration.wakeupTime = newValue
-          Statsig.logEvent("settingsView.wakeUpTimeChanged")
+          AnalyticsLogger.log(eventName: "settingsView.wakeUpTimeChanged")
         }
         
         Toggle("Keep screen on", isOn: $isIdleTimerDisabled)
@@ -56,7 +55,7 @@ struct SettingsView: View {
               return
             }
             self.userConfiguration.isIdleTimerDisabled = newValue
-            Statsig.logEvent("settingsView.keepScreenOnChanged", metadata: ["state": String(newValue)])
+            AnalyticsLogger.log(eventName: "settingsView.keepScreenOnChanged", metadata: ["state": String(newValue)])
           }
       }
       
@@ -74,7 +73,8 @@ struct SettingsView: View {
             Button("Add Event") {
               userConfiguration.countdownEvents.append(newCountdownEvent)
               newCountdownEvent = CountdownEvent(date: Date(), name: "")
-              Statsig.logEvent("settingsView.newEventAdded")
+              
+              AnalyticsLogger.log(eventName: "settingsView.newEventAdded")
             }
             .disabled(newCountdownEvent.name.isEmpty)
           case .edit(id: let id):
@@ -84,7 +84,7 @@ struct SettingsView: View {
               newCountdownEvent = CountdownEvent(date: Date(), name: "")
               newCountdownEventMode = .add
               
-              Statsig.logEvent("settingsView.existingEventUpdated")
+              AnalyticsLogger.log(eventName: "settingsView.existingEventUpdated")
             }
             .disabled(newCountdownEvent.name.isEmpty)
         }
@@ -92,13 +92,13 @@ struct SettingsView: View {
       
       Section("Countdown Events") {
         List(userConfiguration.sortedCountdownEvents) { event in
-          EventNameView(event: event, mode: Statsig.checkGate("edit_event") ? .editable : .readonly, handleRemoveEvent: { event in
+          EventNameView(event: event, mode: AnalyticsLogger.checkGate(gateName: "edit_event") ? .editable : .readonly, handleRemoveEvent: { event in
             guard let index = userConfiguration.countdownEvents.firstIndex(of: event) else {
               return
             }
                   
             userConfiguration.countdownEvents.remove(at: index)
-            Statsig.logEvent("settingsView.eventDeleted")
+            AnalyticsLogger.log(eventName: "settingsView.eventDeleted")
           }) { updateEvent in
             newCountdownEvent.name = updateEvent.name
             newCountdownEvent.date = updateEvent.date
@@ -115,7 +115,7 @@ struct SettingsView: View {
       .navigationBarTitleDisplayMode(.inline)
     #endif
       .onAppear {
-        Statsig.logEvent("settingsViewDidAppear")
+        AnalyticsLogger.log(eventName: "settingsViewDidAppear")
       }
   }
 }

--- a/VisWakeClock/Utilities/AnalyticsLogger.swift
+++ b/VisWakeClock/Utilities/AnalyticsLogger.swift
@@ -1,0 +1,58 @@
+//
+//  AnalyticsLogger.swift
+//  VisWakeClock
+//
+//  Created by Eric Masiello on 5/3/25.
+//
+
+import Statsig
+import SwiftUI
+
+class AnalyticsLogger {
+  static func initialize() {
+    // Only initialize Statsig if we're not in a test or simulator environment
+    if EnvironmentHelper.shouldSendToAnalytics() == false {
+      return
+    }
+    Statsig.initialize(sdkKey: "client-hnmNZKXyozBgNH11IxjD2iAwTZ1b9YlYQrq4fHQwC56") { error in
+      if let error = error {
+        /**
+         note: this can happen if the user is offline so we may want to expore batter patterns for this or potentially
+         not logging it whatsoever.
+         */
+        ErrorLogger.log(message: "Failed to initialized Statsig with error \(String(describing: error))")
+        return
+      }
+    }
+  }
+  
+  static func shutDown(scenePhase: ScenePhase) {
+    if EnvironmentHelper.shouldSendToAnalytics() == false {
+      return
+    }
+    
+    /**
+     I'm unclear if this is the best pattern but the Statsig docs recommend flushing the events when the app goes inactive/background.
+     See https://docs.statsig.com/client/iosClientSDK#shutting-statsig-down
+     */
+    if scenePhase == .inactive || scenePhase == .background {
+      Statsig.shutdown()
+    }
+  }
+  
+  static func updateUserWithResult(userId: String) {
+    if EnvironmentHelper.shouldSendToAnalytics() {
+      Statsig.updateUserWithResult(StatsigUser(userID: userId))
+    }
+  }
+  
+  static func log(eventName: String, metadata: [String: String]? = nil) {
+    if EnvironmentHelper.shouldSendToAnalytics() {
+      Statsig.logEvent(eventName, metadata: metadata)
+    }
+  }
+  
+  static func checkGate(gateName: String) -> Bool {
+    Statsig.checkGate("edit_event")
+  }
+}

--- a/VisWakeClock/Utilities/EnvironmentHelper.swift
+++ b/VisWakeClock/Utilities/EnvironmentHelper.swift
@@ -1,0 +1,28 @@
+//
+//  EnvironmentHelper.swift
+//  VisWakeClock
+//
+//  Created by Claude on 5/1/2025.
+//
+
+import Foundation
+
+enum EnvironmentHelper {
+  /// Determines if the app is running in a test or simulator environment
+  /// - Returns: Boolean indicating if we're in a test or simulator environment
+  static func isTestOrSimulatorEnvironment() -> Bool {
+    #if targetEnvironment(simulator)
+      return true
+    #else
+      // Check for XCTest presence
+      let isRunningXCTest = NSClassFromString("XCTestCase") != nil
+      return isRunningXCTest
+    #endif
+  }
+
+  /// Determines if we should send data to analytics/monitoring services
+  /// - Returns: Boolean indicating if we should send data
+  static func shouldSendToAnalytics() -> Bool {
+    return !isTestOrSimulatorEnvironment()
+  }
+}

--- a/VisWakeClock/Utilities/ErrorLogger.swift
+++ b/VisWakeClock/Utilities/ErrorLogger.swift
@@ -1,0 +1,46 @@
+//
+//  ErrorLogger.swift
+//  VisWakeClock
+//
+//  Created by Eric Masiello on 5/3/25.
+//
+
+import Sentry
+
+class ErrorLogger {
+  static func initialize() {
+    guard !EnvironmentHelper.shouldSendToAnalytics() else {
+      return
+    }
+
+    SentrySDK.start { options in
+      options.dsn = "https://8a8857516c36a9daf0014ff6e680d6bd@o218382.ingest.us.sentry.io/4508480854032384"
+      options.debug = true // Enabled debug when first installing is always helpful
+      // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+      // We recommend adjusting this value in production.
+      options.tracesSampleRate = 1.0
+
+      // Sample rate for profiling, applied on top of TracesSampleRate.
+      // We recommend adjusting this value in production.
+      options.profilesSampleRate = 1.0
+
+      // Uncomment the following lines to add more data to your events
+      options.attachScreenshot = true // This adds a screenshot to the error events
+      options.attachViewHierarchy = true // This adds the view hierarchy to the error events
+    }
+  }
+
+  static func log(error: Error) {
+    guard !EnvironmentHelper.shouldSendToAnalytics() else {
+      return
+    }
+    SentrySDK.capture(error: error)
+  }
+
+  static func log(message: String) {
+    guard !EnvironmentHelper.shouldSendToAnalytics() else {
+      return
+    }
+    SentrySDK.capture(message: message)
+  }
+}

--- a/VisWakeClock/VisWakeClockApp.swift
+++ b/VisWakeClock/VisWakeClockApp.swift
@@ -5,40 +5,16 @@
 //  Created by Eric Masiello on 9/15/24.
 //
 
-import Sentry
+// Import the environment helper
+import Foundation
 import SwiftData
 import SwiftUI
-import Statsig
 
 @main
 struct VisWakeClockApp: App {
   init() {
-    SentrySDK.start { options in
-      options.dsn = "https://8a8857516c36a9daf0014ff6e680d6bd@o218382.ingest.us.sentry.io/4508480854032384"
-      options.debug = true // Enabled debug when first installing is always helpful
-      // Set tracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
-      // We recommend adjusting this value in production.
-      options.tracesSampleRate = 1.0
-
-      // Sample rate for profiling, applied on top of TracesSampleRate.
-      // We recommend adjusting this value in production.
-      options.profilesSampleRate = 1.0
-
-      // Uncomment the following lines to add more data to your events
-      options.attachScreenshot = true // This adds a screenshot to the error events
-      options.attachViewHierarchy = true // This adds the view hierarchy to the error events
-    }
-    
-    Statsig.initialize(sdkKey: "client-hnmNZKXyozBgNH11IxjD2iAwTZ1b9YlYQrq4fHQwC56") { error in
-      if let error = error {
-        /**
-         note: this can happen if the user is offline so we may want to expore batter patterns for this or potentially
-         not logging it whatsoever.
-         */
-        SentrySDK.capture(message: "Failed to initialized Statsig with error \(String(describing: error))")
-        return
-      }
-    }
+    ErrorLogger.initialize()
+    AnalyticsLogger.initialize()
   }
 
   var body: some Scene {

--- a/VisWakeClock/Weather/LocationManager.swift
+++ b/VisWakeClock/Weather/LocationManager.swift
@@ -15,7 +15,6 @@
 import Combine
 import CoreLocation
 import Foundation
-import Sentry
 
 struct GPSCoordinateNormalizer {
   /// Normalizes GPS coordinates and provides comparison with a minimum distance threshold
@@ -129,7 +128,7 @@ final class LocationManager: NSObject, ObservableObject, CLLocationManagerDelega
 
   func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
     guard let error = (error as NSError?), error.domain == kCLErrorDomain else {
-      SentrySDK.capture(error: error)
+      ErrorLogger.log(error: error)
       return
     }
 

--- a/VisWakeClock/Weather/WeatherManager.swift
+++ b/VisWakeClock/Weather/WeatherManager.swift
@@ -7,7 +7,6 @@
 
 import Combine
 import CoreLocation
-import Sentry
 
 enum WeatherError: Error {
   case invalidResponse
@@ -22,7 +21,7 @@ class WeatherManager: ObservableObject {
 
   private var cachedCoordinates: (latitude: Double, longitude: Double)? = nil
   private var locationChangeCancellables = Set<AnyCancellable>()
-  private let timerFrequency = 1.0 * 60 * 30  // fetch weather every 30 mins
+  private let timerFrequency = 1.0 * 60 * 30 // fetch weather every 30 mins
   private var timerCancellable: AnyCancellable?
   private var coordinateChangeTask: Task<Void, Never>?
   private var timerTask: Task<Void, Never>?
@@ -40,17 +39,16 @@ class WeatherManager: ObservableObject {
             self?.weather = try await WeatherClient.getWeather(
               latitude: coordinates.latitude, longitude: coordinates.longitude)
           } catch {
-            SentrySDK.capture(error: error)
+            ErrorLogger.log(error: error)
           }
         }
-        
-        
+
         self?.isLoading = false
       }
       .store(in: &locationChangeCancellables)
 
     self.timerCancellable = Timer.publish(every: timerFrequency, on: .main, in: .default)
-      .autoconnect()  // Automatically connect to start receiving updates
+      .autoconnect() // Automatically connect to start receiving updates
       .sink { [weak self] _ in
         self?.timerTask = Task {
           debugPrint("[timer] Fetching Weather Data from WeatherManager")
@@ -60,7 +58,7 @@ class WeatherManager: ObservableObject {
             self?.weather = try await WeatherClient.getWeather(
               latitude: coordinates.latitude, longitude: coordinates.longitude)
           } catch {
-            SentrySDK.capture(error: error)
+            ErrorLogger.log(error: error)
           }
         }
       }


### PR DESCRIPTION
Wraps 3rd party loggers (Statsig for analytics, Sentry for errors) in a facade so that we can control sending events only when not running in a test or simulator env

Closes #17 